### PR TITLE
Refactor: one option per post type, per-type enabled filters

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -13,6 +13,15 @@
 	<!-- Rules: figuren.theater Coding Standards -->
 	<rule ref="figurentheater" />
 
+	<!-- Allow additional text_domains -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="gatherpress-cache-invalidation-hooks"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">

--- a/includes/classes/class-option-tracker.php
+++ b/includes/classes/class-option-tracker.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 		 */
 		public function is_post_type_enabled( string $post_type ): bool {
 			// 1. Deprecated filter — apply_filters_deprecated() fires the notice
-			//    and runs any hooked callbacks so backwards compatibility is preserved.
+			// and runs any hooked callbacks so backwards compatibility is preserved.
 			if ( apply_filters_deprecated(
 				'gatherpress_upcoming_events_option_tracker_enabled',
 				array( false ),
@@ -284,7 +284,6 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 					continue;
 				}
 
-				// @phpstan-ignore-next-line
 				if ( $event->has_event_past() ) {
 					/**
 					 * Trigger the main event end action hook.
@@ -385,7 +384,12 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 
 			return array_values(
 				array_filter(
-					array_map( 'intval', $raw ),
+					array_map(
+						static function ( mixed $v ): int {
+							return is_scalar( $v ) ? (int) $v : 0;
+						},
+						$raw
+					),
 					static fn( int $id ) => $id > 0
 				)
 			);
@@ -421,11 +425,11 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 				return $context->post_type;
 			}
 
-			if ( $context instanceof Core\Event && isset( $context->event ) && $context->event instanceof WP_Post ) {
+			if ( $context instanceof Core\Event && isset( $context->event ) ) {
 				return $context->event->post_type;
 			}
 
-			// Fall back to a fresh get_post() lookup.
+			// Fall back to a fresh get_post() lookup (context is int or unresolvable Event).
 			$post = get_post( $post_id );
 			return $post instanceof WP_Post ? $post->post_type : '';
 		}

--- a/includes/classes/class-option-tracker.php
+++ b/includes/classes/class-option-tracker.php
@@ -8,6 +8,7 @@
 namespace GatherPress_Cache_Invalidation_Hooks;
 
 use GatherPress\Core;
+use WP_Post;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit; // @codeCoverageIgnore
@@ -17,15 +18,21 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 	 * Upcoming Events Option Tracker (Optional)
 	 *
 	 * An optional redundant tracking system can be enabled via filter to prevent missed events:
-	 * 1. All upcoming events are stored in a wp_option array
-	 * 2. A daily cron job checks this list for any events that have ended
-	 * 3. If an event's cron job failed, the daily check catches it and triggers cleanup
+	 * 1. Each post type that supports `gatherpress-event-date` gets its own wp_option tracking list.
+	 * 2. A daily cron job checks every list for posts whose end date has passed.
+	 * 3. If a scheduled cron job failed, the daily check catches it and triggers cleanup.
+	 *
+	 * One option key is maintained per supporting post type:
+	 *   `upcoming_{$post_type}s`
+	 *
+	 * This avoids mixing IDs from different post types in a single option and ensures that
+	 * validation always uses the correct GatherPress event object for the right type.
 	 *
 	 * Why Optional:
-	 * The upcoming events option tracker requires additional database writes on every event status change.
-	 * Most sites have reliable cron systems and don't need this redundancy. It's disabled
-	 * by default to minimize unnecessary database operations, but can be enabled for
-	 * high-value deployments where missing an event cleanup would be critical.
+	 * The upcoming events option tracker requires additional database writes on every event
+	 * status change. Most sites have reliable cron systems and don't need this redundancy.
+	 * It's disabled by default to minimize unnecessary database operations, but can be enabled
+	 * for high-value deployments where missing an event cleanup would be critical.
 	 *
 	 * To enable upcoming events option tracker:
 	 * add_filter( 'gatherpress_upcoming_events_option_tracker_enabled', '__return_true' );
@@ -46,17 +53,25 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 		const CRON_HOOK = 'gatherpress_validate_events_ended';
 
 		/**
-		 * The wp_option key for tracking upcoming events.
+		 * Prefix for the per-post-type wp_option tracking keys.
+		 *
+		 * The full key for a given post type is built as:
+		 *   self::OPTION_KEY_PREFIX . $post_type . 's'
+		 *
+		 * e.g. 'upcoming_gatherpress_events'
+		 *      'upcoming_gatherpress_productions'
 		 *
 		 * @since 0.1.0
 		 * @var string
 		 */
-		const OPTION_KEY = 'gatherpress_upcoming_events';
+		const OPTION_KEY_PREFIX = 'upcoming_';
 
 		/**
 		 * Constructor for the Setup class.
 		 *
 		 * Initializes and sets up various components of the plugin.
+		 *
+		 * @since 0.1.0
 		 */
 		protected function __construct() {
 			$this->setup_hooks();
@@ -66,224 +81,353 @@ if ( ! class_exists( 'Option_Tracker' ) ) {
 		 * Set up hooks for various purposes.
 		 *
 		 * Registers all necessary hooks:
-		 * - Monitors post status changes to manage redundant event tracking
-		 * - Cleans up tracking before post deletion
-		 * - Performs daily checks for ended events that may have been missed
-		 * - Schedules the daily cron job if enabled
+		 * - Monitors post status changes to manage redundant event tracking.
+		 * - Cleans up tracking before post deletion.
+		 * - Performs daily checks for ended events that may have been missed.
+		 * - Schedules the daily cron job if enabled.
 		 *
 		 * @since 0.1.0
 		 *
 		 * @return void
 		 */
 		protected function setup_hooks(): void {
+			// Always register the action hooks. Each callback checks per-post-type
+			// enablement at runtime so newly enabled types are picked up without
+			// needing to flush any cached gate result.
+			add_action( 'gatherpress_cache_invalidation_hooks_new_upcoming', array( $this, 'add_to_tracking' ), 10, 2 );
+			add_action( 'gatherpress_cache_invalidation_hooks_clear', array( $this, 'remove_from_tracking' ), 10, 2 );
+			add_action( Cron_Scheduler::ACTION_HOOK, array( $this, 'remove_from_tracking' ), 10, 2 );
+			add_action( self::CRON_HOOK, array( $this, 'validate_events_ended' ) );
 
-			if ( ! $this->is_tracker_enabled() ) {
-				return;
-			}
-
-			// Waiting for post status transitions, post_meta changes or post delete.
-			add_action( 'gatherpress_cache_invalidation_hooks_new_upcoming', array( $this, 'add_to_tracking' ) );
-			add_action( 'gatherpress_cache_invalidation_hooks_clear', array( $this, 'remove_from_tracking' ) );
-
-			// An event ended regularly, remove it from tracking.
-			add_action( Cron_Scheduler::ACTION_HOOK, array( $this, 'remove_from_tracking' ) );
-
-			// Schedule the daily check if not already scheduled.
-			if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			// Schedule the daily cron only when at least one post type is enabled.
+			if ( $this->any_post_type_enabled() && ! wp_next_scheduled( self::CRON_HOOK ) ) {
 				wp_schedule_event( time(), 'daily', self::CRON_HOOK );
 			}
-			add_action( self::CRON_HOOK, array( $this, 'validate_events_ended' ) );
 		}
 
 		/**
-		 * Check if upcoming events option tracker is enabled.
+		 * Returns true when the tracker is enabled for the given post type.
+		 *
+		 * Resolution order (first truthy value wins):
+		 * 1. Deprecated filter `gatherpress_upcoming_events_option_tracker_enabled`
+		 *    — handled via `apply_filters_deprecated()`, which fires a notice and
+		 *      still runs any hooked callbacks for backwards compatibility.
+		 * 2. General filter `gatherpress_upcoming_tracker_enabled` — enables all
+		 *    supporting post types at once.
+		 * 3. Per-type filter `{$post_type}_upcoming_tracker_enabled` — enables a
+		 *    single post type independently.
 		 *
 		 * @since 0.1.0
 		 *
-		 * @return bool True if upcoming events option tracker is enabled, false otherwise.
+		 * @param string $post_type The post type slug to check.
+		 * @return bool True when the tracker should run for this post type.
 		 */
-		public function is_tracker_enabled(): bool {
+		public function is_post_type_enabled( string $post_type ): bool {
+			// 1. Deprecated filter — apply_filters_deprecated() fires the notice
+			//    and runs any hooked callbacks so backwards compatibility is preserved.
+			if ( apply_filters_deprecated(
+				'gatherpress_upcoming_events_option_tracker_enabled',
+				array( false ),
+				'0.2.0',
+				sprintf(
+					/* translators: 1: new general filter name, 2: per-type filter pattern */
+					__(
+						'Use "%1$s" to enable all post types, or "%2$s" for a specific post type.',
+						'gatherpress-cache-invalidation-hooks'
+					),
+					'gatherpress_upcoming_tracker_enabled',
+					'{post_type}_upcoming_tracker_enabled'
+				)
+			) ) {
+				return true;
+			}
+
 			/**
-			 * Filter whether to enable the upcoming events option tracker tracking system.
+			 * Filter whether to enable the tracker for all supporting post types at once.
 			 *
-			 * The upcoming events option tracker provides redundant tracking of upcoming events and a daily
-			 * cron job to catch any events whose scheduled cron jobs failed. This adds
-			 * database writes on every event status change, so it's disabled by default.
-			 *
-			 * Enable for high-value deployments where missing an event cleanup would be critical.
+			 * When true, every post type that declares `gatherpress-event-date` support
+			 * gets its own tracking option and is included in the daily cron check.
 			 *
 			 * @example
 			 * ```php
-			 * // Enable upcoming events option tracker
-			 * add_filter( 'gatherpress_upcoming_events_option_tracker_enabled', '__return_true' );
+			 * add_filter( 'gatherpress_upcoming_tracker_enabled', '__return_true' );
 			 * ```
 			 *
-			 * @since 0.1.0
+			 * @since 0.2.0
 			 *
-			 * @param bool $enabled Whether upcoming events option tracker is enabled. Default false.
+			 * @param bool   $enabled   Whether the tracker is globally enabled. Default false.
+			 * @param string $post_type The post type currently being evaluated.
 			 */
-			return apply_filters( 'gatherpress_upcoming_events_option_tracker_enabled', false );
+			if ( apply_filters( 'gatherpress_upcoming_tracker_enabled', false, $post_type ) ) {
+				return true;
+			}
+
+			/**
+			 * Filter whether to enable the tracker for a specific post type.
+			 *
+			 * The dynamic portion of the hook name, `$post_type`, refers to the
+			 * post type slug, e.g. `gatherpress_event` or `gatherpress_production`.
+			 *
+			 * Possible hook names include:
+			 *  - `gatherpress_event_upcoming_tracker_enabled`
+			 *  - `gatherpress_production_upcoming_tracker_enabled`
+			 *
+			 * @example
+			 * ```php
+			 * add_filter( 'gatherpress_event_upcoming_tracker_enabled', '__return_true' );
+			 * ```
+			 *
+			 * @since 0.2.0
+			 *
+			 * @param bool $enabled Whether the tracker is enabled for this post type. Default false.
+			 */
+			return (bool) apply_filters( "{$post_type}_upcoming_tracker_enabled", false );
 		}
 
+		/**
+		 * Returns true when at least one supporting post type has the tracker enabled.
+		 *
+		 * Used by setup_hooks() to decide whether to schedule the daily cron.
+		 *
+		 * @since 0.2.0
+		 *
+		 * @return bool
+		 */
+		public function any_post_type_enabled(): bool {
+			foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+				if ( $this->is_post_type_enabled( $post_type ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/**
+		 * Returns the wp_option key for tracking a specific post type.
+		 *
+		 * Each post type that declares `gatherpress-event-date` support gets its
+		 * own option so IDs from different types are never mixed.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param string $post_type The post type slug.
+		 * @return string The option key, e.g. 'upcoming_gatherpress_events'.
+		 */
+		public function option_key_for( string $post_type ): string {
+			return self::OPTION_KEY_PREFIX . $post_type . 's';
+		}
 
 		/**
 		 * Daily cron job to check for events that ended but weren't processed.
 		 *
-		 * If a scheduled cron job fails (server issues,
-		 * high load, etc.), this daily check ensures we eventually catch and
-		 * process ended events.
+		 * Iterates every post type that declares `gatherpress-event-date` support,
+		 * reads its dedicated tracking option, and validates each stored ID.
 		 *
-		 * Only runs when the upcoming events option tracker feature is enabled via the
-		 * 'gatherpress_upcoming_events_option_tracker_enabled' filter.
+		 * If a scheduled cron job fails (server issues, high load, etc.), this
+		 * daily check ensures we eventually catch and process ended events.
 		 *
-		 * Why daily: Balances thoroughness with resource usage. More frequent
-		 * checks would catch events sooner but increase server load. Daily is
-		 * reasonable for most use cases.
-		 *
-		 * Logic flow:
-		 * 1. Get all tracked upcoming event IDs from wp_option
-		 * 2. Loop through each ID
-		 * 3. Check if event has ended using GatherPress's validation
-		 * 4. If ended, trigger the normal end handling
-		 * 5. Remove from tracking (handled by validate_event_ended)
+		 * Logic flow per post type:
+		 * 1. Read the per-type option (list of upcoming post IDs).
+		 * 2. For each ID: load the post, confirm it still has the right post type.
+		 * 3. Instantiate Core\Event and check has_event_past().
+		 * 4. If ended, fire ACTION_HOOK (which also removes from tracking).
+		 * 5. If the post no longer exists or has wrong type, remove from tracking.
 		 *
 		 * @since 0.1.0
 		 *
 		 * @return void
 		 */
 		public function validate_events_ended(): void {
+			$supporting_types = get_post_types_by_support( 'gatherpress-event-date' );
 
-			// Get all tracked event IDs.
-			$tracked_ids_raw = get_option( self::OPTION_KEY, array() );
+			foreach ( $supporting_types as $post_type ) {
+				$this->validate_events_ended_for_type( $post_type );
+			}
+		}
 
-			// Ensure we have an array of integers.
-			if ( ! is_array( $tracked_ids_raw ) ) {
+		/**
+		 * Validates tracked event IDs for a single post type.
+		 *
+		 * Separated from validate_events_ended() so each post type is processed
+		 * independently — a bad ID in one type's list cannot abort processing of
+		 * another type's list.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param string $post_type The post type slug to validate.
+		 * @return void
+		 */
+		private function validate_events_ended_for_type( string $post_type ): void {
+			if ( ! $this->is_post_type_enabled( $post_type ) ) {
 				return;
 			}
 
-			/**
-			 * Cast to int array for type safety
-			 *
-			 * @var array<int> $tracked_ids
-			 */
-			$tracked_ids = array_filter(
-				array_map( '\intval', $tracked_ids_raw ),
-				function ( $id ) {
-					return $id > 0;
-				}
-			);
+			$tracked_ids = $this->get_tracked_ids( $post_type );
 
-			// Early return if no events to check.
 			if ( empty( $tracked_ids ) ) {
 				return;
 			}
 
-			// Check each tracked event.
-			foreach ( $tracked_ids as $event_id ) {
-				$event = new Core\Event( $event_id );
+			foreach ( $tracked_ids as $post_id ) {
+				$post = get_post( $post_id );
 
-				if ( ! isset( $event->event ) || ! post_type_supports( $event->event->post_type, 'gatherpress-event-date' ) ) {
-					// Clean up tracking for non-existent events.
-					$this->remove_from_tracking( $event_id );
+				// Clean up stale entries: post gone or post type changed.
+				if ( ! $post instanceof WP_Post || $post->post_type !== $post_type ) {
+					$this->remove_id_from_option( $post_id, $post_type );
 					continue;
 				}
 
-				// Check if event has ended.
-				// @phpstan-ignore-next-line.
-				if ( method_exists( $event, 'has_event_past' ) && $event->has_event_past() ) {
+				$event = new Core\Event( $post_id );
 
+				// @phpstan-ignore-next-line
+				if ( ! method_exists( $event, 'has_event_past' ) ) {
+					continue;
+				}
+
+				// @phpstan-ignore-next-line
+				if ( $event->has_event_past() ) {
 					/**
 					 * Trigger the main event end action hook.
 					 *
-					 * Central hook for event end processing.
-					 * All cleanup operations (cache invalidation, tracking removal, etc.)
-					 * are hooked to this action at various priorities.
+					 * Central hook for event end processing. All cleanup operations
+					 * (cache invalidation, tracking removal, etc.) are hooked to this
+					 * action at various priorities.
 					 *
 					 * @since 0.1.0
-					 * @param int        $event_id The ID of the event that ended.
-					 * @param Core\Event $event    The GatherPress event object.
+					 * @param int        $post_id The ID of the event that ended.
+					 * @param Core\Event $event   The GatherPress event object.
 					 */
-					do_action( Cron_Scheduler::ACTION_HOOK, $event_id, $event );
+					do_action( Cron_Scheduler::ACTION_HOOK, $post_id, $event );
 				}
 			}
 		}
 
 		/**
-		 * Add an event ID to the tracking list.
+		 * Add a post ID to the tracking list for its post type.
 		 *
-		 * Maintains an array of upcoming event IDs in wp_options. This list serves
-		 * as our safety net for catching events whose cron jobs failed.
+		 * Determines the post type from the WP_Post object passed as the second
+		 * argument (provided by gatherpress_cache_invalidation_hooks_new_upcoming)
+		 * and writes the ID into the dedicated per-type option.
 		 *
-		 * Only operates when upcoming events option tracker is enabled.
-		 *
-		 * @since 0.1.0
-		 *
-		 * @param int $event_id The event post ID to add to tracking.
-		 *
-		 * @return void
-		 */
-		public function add_to_tracking( int $event_id ): void {
-			// Get current tracking list.
-			$tracked_ids_raw = get_option( self::OPTION_KEY, array() );
-
-			// Ensure we have an array.
-			if ( ! is_array( $tracked_ids_raw ) ) {
-				$tracked_ids_raw = array();
-			}
-
-			/**
-			 * Cast to int array for type safety
-			 *
-			 * @var array<int> $tracked_ids
-			 */
-			$tracked_ids = array_map( '\intval', $tracked_ids_raw );
-
-			// Add the new ID.
-			$tracked_ids[] = $event_id;
-
-			// Remove duplicates and re-index.
-			$tracked_ids = array_values( array_unique( $tracked_ids ) );
-
-			// Save back to database.
-			update_option( self::OPTION_KEY, $tracked_ids );
-		}
-
-		/**
-		 * Remove an event ID from the tracking list.
-		 *
-		 * Called when an event is unpublished, deleted, or successfully processed.
-		 * Keeps the tracking list clean and accurate.
-		 *
-		 * Only operates when upcoming events option tracker is enabled.
+		 * Only operates when the upcoming events option tracker is enabled.
 		 *
 		 * @since 0.1.0
 		 *
-		 * @param int $event_id The event post ID to remove from tracking.
+		 * @param int     $post_id The event post ID to add to tracking.
+		 * @param WP_Post $post    The post object (used to resolve the post type).
 		 *
 		 * @return void
 		 */
-		public function remove_from_tracking( int $event_id ): void {
-			// Get current tracking list.
-			$tracked_ids_raw = get_option( self::OPTION_KEY, array() );
-			if ( ! is_array( $tracked_ids_raw ) ) {
+		public function add_to_tracking( int $post_id, WP_Post $post ): void {
+			if ( ! $this->is_post_type_enabled( $post->post_type ) ) {
 				return;
 			}
 
-			/**
-			 * Cast to int array for type safety
-			 *
-			 * @var array<int> $tracked_ids
-			 */
-			$tracked_ids = array_map( '\intval', $tracked_ids_raw );
+			$tracked_ids   = $this->get_tracked_ids( $post->post_type );
+			$tracked_ids[] = $post_id;
+			$tracked_ids   = array_values( array_unique( $tracked_ids ) );
 
-			// Cleanly removes all instances of the target ID.
-			$tracked_ids = array_diff( $tracked_ids, array( $event_id ) );
+			update_option( $this->option_key_for( $post->post_type ), $tracked_ids );
+		}
 
-			// Re-index array to remove gaps.
-			$tracked_ids = array_values( $tracked_ids );
+		/**
+		 * Remove a post ID from the tracking list for its post type.
+		 *
+		 * Called when a post is unpublished, deleted, or successfully processed.
+		 * The second argument accepts either a WP_Post or null so the method can
+		 * be called from ACTION_HOOK which passes a Core\Event as second arg —
+		 * in that case the post type is resolved from the event object itself.
+		 *
+		 * Only operates when the upcoming events option tracker is enabled.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param int                    $post_id The event post ID to remove from tracking.
+		 * @param WP_Post|Core\Event|int $context WP_Post, Core\Event, or a bare post ID.
+		 *                                        Used only to resolve the post type.
+		 *
+		 * @return void
+		 */
+		public function remove_from_tracking( int $post_id, WP_Post|Core\Event|int $context = 0 ): void {
+			$post_type = $this->resolve_post_type( $post_id, $context );
 
-			// Save back to database.
-			update_option( self::OPTION_KEY, $tracked_ids );
+			if ( '' === $post_type ) {
+				// Fallback: scrub the ID from all enabled supporting types.
+				foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $type ) {
+					if ( $this->is_post_type_enabled( $type ) ) {
+						$this->remove_id_from_option( $post_id, $type );
+					}
+				}
+				return;
+			}
+
+			if ( ! $this->is_post_type_enabled( $post_type ) ) {
+				return;
+			}
+
+			$this->remove_id_from_option( $post_id, $post_type );
+		}
+
+		/**
+		 * Reads and normalises the tracking list for a given post type.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param string $post_type The post type slug.
+		 * @return array<int> Array of tracked post IDs (may be empty).
+		 */
+		private function get_tracked_ids( string $post_type ): array {
+			$raw = get_option( $this->option_key_for( $post_type ), array() );
+
+			if ( ! is_array( $raw ) ) {
+				return array();
+			}
+
+			return array_values(
+				array_filter(
+					array_map( 'intval', $raw ),
+					static fn( int $id ) => $id > 0
+				)
+			);
+		}
+
+		/**
+		 * Removes a single ID from the option for the given post type.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param int    $post_id   The post ID to remove.
+		 * @param string $post_type The post type whose option to update.
+		 * @return void
+		 */
+		private function remove_id_from_option( int $post_id, string $post_type ): void {
+			$tracked_ids = $this->get_tracked_ids( $post_type );
+			$tracked_ids = array_values( array_diff( $tracked_ids, array( $post_id ) ) );
+
+			update_option( $this->option_key_for( $post_type ), $tracked_ids );
+		}
+
+		/**
+		 * Resolves a post type string from a mixed context argument.
+		 *
+		 * @since 0.1.0
+		 *
+		 * @param int                    $post_id The post ID (fallback lookup).
+		 * @param WP_Post|Core\Event|int $context Context passed by the caller.
+		 * @return string Post type slug, or '' when it cannot be determined.
+		 */
+		private function resolve_post_type( int $post_id, WP_Post|Core\Event|int $context ): string {
+			if ( $context instanceof WP_Post ) {
+				return $context->post_type;
+			}
+
+			if ( $context instanceof Core\Event && isset( $context->event ) && $context->event instanceof WP_Post ) {
+				return $context->event->post_type;
+			}
+
+			// Fall back to a fresh get_post() lookup.
+			$post = get_post( $post_id );
+			return $post instanceof WP_Post ? $post->post_type : '';
 		}
 	}
 }

--- a/plugin.php
+++ b/plugin.php
@@ -68,12 +68,21 @@ function gatherpress_cache_invalidation_hooks_deactivate(): void {
 	$cron_scheduler = \GatherPress_Cache_Invalidation_Hooks\Cron_Scheduler::get_instance();
 	$option_tracker = \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::get_instance();
 
-	if ( $option_tracker->is_tracker_enabled() ) {
+	$event_post_types = get_post_types_by_support( 'gatherpress-event-date' );
 
-		$upcoming_events = get_option( $option_tracker::OPTION_KEY );
+	if ( $option_tracker->any_post_type_enabled() ) {
+		// Collect tracked IDs from every enabled per-type option.
+		$upcoming_events = array();
+		foreach ( $event_post_types as $post_type ) {
+			if ( $option_tracker->is_post_type_enabled( $post_type ) ) {
+				$tracked = get_option( $option_tracker->option_key_for( $post_type ), array() );
+				if ( is_array( $tracked ) ) {
+					$upcoming_events = array_merge( $upcoming_events, $tracked );
+				}
+			}
+		}
 	} else {
-		$event_post_types = get_post_types_by_support( 'gatherpress-event-date' );
-		$upcoming_events  = new \WP_Query(
+		$upcoming_events = new \WP_Query(
 			array(
 				'post_type'               => $event_post_types,
 				'post_status'             => 'publish',
@@ -98,17 +107,15 @@ function gatherpress_cache_invalidation_hooks_deactivate(): void {
 		$cron_scheduler->invalidate_caches( $event_id );
 	}
 
-	if ( $option_tracker->is_tracker_enabled() ) {
-		// Find the timestamp of the next scheduled daily event.
-		$timestamp = wp_next_scheduled( $option_tracker::CRON_HOOK );
+	// Unschedule the daily validation cron.
+	$timestamp = wp_next_scheduled( $option_tracker::CRON_HOOK );
+	if ( is_int( $timestamp ) && $timestamp > 0 ) {
+		wp_unschedule_event( $timestamp, $option_tracker::CRON_HOOK );
+	}
 
-		// If an event is scheduled, remove it.
-		if ( is_int( $timestamp ) && $timestamp > 0 ) {
-			wp_unschedule_event( $timestamp, $option_tracker::CRON_HOOK );
-		}
-
-		// Delete the tracking option.
-		delete_option( $option_tracker::OPTION_KEY );
+	// Delete all per-type tracking options.
+	foreach ( get_post_types_by_support( 'gatherpress-event-date' ) as $post_type ) {
+		delete_option( $option_tracker->option_key_for( $post_type ) );
 	}
 }
 register_deactivation_hook( __FILE__, 'gatherpress_cache_invalidation_hooks_deactivate' );

--- a/tests/integration/HookRegistrationTest.php
+++ b/tests/integration/HookRegistrationTest.php
@@ -173,29 +173,30 @@ class HookRegistrationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that tracker hooks are NOT registered when feature is disabled.
+	 * Tracker hooks are always registered; per-type enablement is checked
+	 * at runtime inside each callback, not at hook-registration time.
 	 *
 	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker
 	 */
-	public function test_tracker_hooks_not_registered_when_disabled(): void {
-		$this->assertFalse(
+	public function test_tracker_hooks_always_registered(): void {
+		$this->assertNotFalse(
 			has_action( 'gatherpress_cache_invalidation_hooks_new_upcoming', array( $this->tracker, 'add_to_tracking' ) ),
-			'add_to_tracking should not be hooked when tracker is disabled'
+			'add_to_tracking should always be hooked'
 		);
 
-		$this->assertFalse(
+		$this->assertNotFalse(
 			has_action( 'gatherpress_cache_invalidation_hooks_clear', array( $this->tracker, 'remove_from_tracking' ) ),
-			'remove_from_tracking should not be hooked to clear action when tracker is disabled'
+			'remove_from_tracking should always be hooked to clear action'
 		);
 
-		$this->assertFalse(
+		$this->assertNotFalse(
 			has_action( Cron_Scheduler::ACTION_HOOK, array( $this->tracker, 'remove_from_tracking' ) ),
-			'remove_from_tracking should not be hooked to event ended when tracker is disabled'
+			'remove_from_tracking should always be hooked to event ended'
 		);
 
-		$this->assertFalse(
+		$this->assertNotFalse(
 			has_action( Option_Tracker::CRON_HOOK, array( $this->tracker, 'validate_events_ended' ) ),
-			'validate_events_ended should not be hooked when tracker is disabled'
+			'validate_events_ended should always be hooked'
 		);
 	}
 

--- a/tests/integration/UpcomingEventsOptionTrackerTest.php
+++ b/tests/integration/UpcomingEventsOptionTrackerTest.php
@@ -1,271 +1,283 @@
 <?php
 /**
- * Integration tests for the upcoming events option tracker system.
- *
- * Tests the optional redundant tracking system that stores upcoming event IDs
- * in a wp_option and provides a daily cron check for missed events.
+ * Integration tests for the Option_Tracker class.
  *
  * @package GatherPress\Cache_Invalidation_Hooks
- * @since 0.1.0
+ * @since   0.1.0
  */
 
 use GatherPress_Cache_Invalidation_Hooks\Cron_Scheduler;
 use GatherPress_Cache_Invalidation_Hooks\Option_Tracker;
 
 /**
- * Tests for the Option_Tracker class and its integration with the cron scheduler.
- *
- * Covers enabling/disabling tracking, adding/removing event IDs from tracking,
- * and the behavior of the validate_events_ended method.
+ * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker
  */
 class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 
-	/**
-	 * The scheduler instance.
-	 *
-	 * @var Cron_Scheduler
-	 */
-	private Cron_Scheduler $scheduler;
-
-	/**
-	 * The option tracker instance.
-	 *
-	 * @var Option_Tracker
-	 */
 	private Option_Tracker $tracker;
 
-	/**
-	 * Set up test fixtures.
-	 */
+	/** @var string[] */
+	private array $supporting_types;
+
 	public function set_up(): void {
 		parent::set_up();
-		$this->scheduler = Cron_Scheduler::get_instance();
-		$this->tracker   = Option_Tracker::get_instance();
-
-		// Clean up the option before each test.
-		delete_option( Option_Tracker::OPTION_KEY );
+		$this->tracker          = Option_Tracker::get_instance();
+		$this->supporting_types = get_post_types_by_support( 'gatherpress-event-date' );
+		$this->delete_all_tracking_options();
 	}
 
-	/**
-	 * Tear down test fixtures.
-	 */
 	public function tear_down(): void {
-		// Remove any filters we added.
 		remove_all_filters( 'gatherpress_upcoming_events_option_tracker_enabled' );
-
-		// Clean up the option.
-		delete_option( Option_Tracker::OPTION_KEY );
-
+		remove_all_filters( 'gatherpress_upcoming_tracker_enabled' );
+		foreach ( $this->supporting_types as $pt ) {
+			remove_all_filters( "{$pt}_upcoming_tracker_enabled" );
+		}
+		$this->delete_all_tracking_options();
 		parent::tear_down();
 	}
 
-	/**
-	 * Test that tracking is disabled by default.
-	 *
-	 * When disabled, publishing an event should NOT add it to the tracking option.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::is_tracker_enabled
-	 */
-	public function test_tracking_disabled_by_default(): void {
-		$this->assertFalse(
-			$this->tracker->is_tracker_enabled(),
-			'Tracker should be disabled by default'
-		);
+	// ── Helpers ───────────────────────────────────────────────────────────────
 
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
-
-		$this->assertEmpty(
-			$tracked,
-			'Tracking option should be empty when feature is disabled'
-		);
+	private function delete_all_tracking_options(): void {
+		foreach ( $this->supporting_types as $pt ) {
+			delete_option( $this->tracker->option_key_for( $pt ) );
+		}
 	}
 
+	private function require_event_post_type(): string {
+		if ( ! in_array( 'gatherpress_event', $this->supporting_types, true ) ) {
+			$this->markTestSkipped( 'gatherpress_event post type not available.' );
+		}
+		return 'gatherpress_event';
+	}
+
+	private function seed( string $post_type, array $ids ): void {
+		update_option( $this->tracker->option_key_for( $post_type ), $ids );
+	}
+
+	private function tracked( string $post_type ): array {
+		return get_option( $this->tracker->option_key_for( $post_type ), array() );
+	}
+
+	// ── option_key_for() ──────────────────────────────────────────────────────
+
+	/** Option key follows "upcoming_{PT-slug}s" pattern. */
+	public function test_option_key_pattern(): void {
+		$this->assertSame( 'upcoming_gatherpress_events', $this->tracker->option_key_for( 'gatherpress_event' ) );
+		$this->assertSame( 'upcoming_gatherpress_productions', $this->tracker->option_key_for( 'gatherpress_production' ) );
+	}
+
+	// ── is_post_type_enabled() — default off ─────────────────────────────────
+
+	/** Every supporting type is disabled by default. */
+	public function test_disabled_by_default_for_all_types(): void {
+		foreach ( $this->supporting_types as $pt ) {
+			$this->assertFalse( $this->tracker->is_post_type_enabled( $pt ), "Should be disabled by default for {$pt}" );
+		}
+	}
+
+	// ── is_post_type_enabled() — general filter ───────────────────────────────
+
+	/** General filter enables every supporting post type. */
+	public function test_general_filter_enables_all_types(): void {
+		add_filter( 'gatherpress_upcoming_tracker_enabled', '__return_true' );
+		foreach ( $this->supporting_types as $pt ) {
+			$this->assertTrue( $this->tracker->is_post_type_enabled( $pt ), "General filter should enable {$pt}" );
+		}
+	}
+
+	/** General filter receives the post type as second argument. */
+	public function test_general_filter_receives_post_type_argument(): void {
+		$post_type = $this->require_event_post_type();
+		$captured  = null;
+		add_filter(
+			'gatherpress_upcoming_tracker_enabled',
+			function ( bool $enabled, string $pt ) use ( &$captured ): bool {
+				$captured = $pt;
+				return false;
+			},
+			10,
+			2
+		);
+		$this->tracker->is_post_type_enabled( $post_type );
+		$this->assertSame( $post_type, $captured );
+	}
+
+	// ── is_post_type_enabled() — per-type filter ─────────────────────────────
+
+	/** Per-type filter enables only its own type. */
+	public function test_per_type_filter_enables_only_that_type(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+
+		$this->assertTrue( $this->tracker->is_post_type_enabled( $post_type ) );
+
+		foreach ( $this->supporting_types as $other ) {
+			if ( $other === $post_type ) {
+				continue;
+			}
+			$this->assertFalse( $this->tracker->is_post_type_enabled( $other ), "Should not enable {$other}" );
+		}
+	}
+
+	// ── is_post_type_enabled() — deprecated filter ────────────────────────────
+
 	/**
-	 * Test that remove_from_tracking cleans the option array.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::remove_from_tracking
+	 * Deprecated filter still enables tracking and fires a deprecation notice
+	 * via apply_filters_deprecated() (which calls doing_it_wrong internally).
 	 */
-	public function test_remove_from_tracking_cleans_option(): void {
-		// Manually set some tracked IDs.
-		update_option( Option_Tracker::OPTION_KEY, array( 10, 20, 30 ) );
+	public function test_deprecated_filter_honoured_with_notice(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( 'gatherpress_upcoming_events_option_tracker_enabled', '__return_true' );
+		$this->setExpectedIncorrectUsage( 'apply_filters_deprecated' );
+		$this->assertTrue( $this->tracker->is_post_type_enabled( $post_type ) );
+	}
 
-		$this->tracker->remove_from_tracking( 20 );
+	/** Deprecated filter returning false still fires the deprecation notice. */
+	public function test_deprecated_filter_false_still_fires_notice(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( 'gatherpress_upcoming_events_option_tracker_enabled', '__return_false' );
+		$this->setExpectedIncorrectUsage( 'apply_filters_deprecated' );
+		$this->assertFalse( $this->tracker->is_post_type_enabled( $post_type ) );
+	}
 
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
+	// ── any_post_type_enabled() ───────────────────────────────────────────────
 
-		$this->assertCount( 2, $tracked );
+	/** Returns false when nothing is enabled. */
+	public function test_any_post_type_enabled_default_false(): void {
+		$this->assertFalse( $this->tracker->any_post_type_enabled() );
+	}
+
+	/** Returns true via the general filter. */
+	public function test_any_post_type_enabled_via_general_filter(): void {
+		add_filter( 'gatherpress_upcoming_tracker_enabled', '__return_true' );
+		$this->assertTrue( $this->tracker->any_post_type_enabled() );
+	}
+
+	/** Returns true when a single per-type filter is active. */
+	public function test_any_post_type_enabled_via_per_type_filter(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$this->assertTrue( $this->tracker->any_post_type_enabled() );
+	}
+
+	// ── add_to_tracking() ─────────────────────────────────────────────────────
+
+	/** Writes the post ID into the correct per-type option. */
+	public function test_add_to_tracking_writes_to_correct_option(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+
+		$post = $this->factory()->post->create_and_get( array( 'post_type' => $post_type, 'post_status' => 'publish' ) );
+		$this->tracker->add_to_tracking( $post->ID, $post );
+
+		$this->assertContains( $post->ID, $this->tracked( $post_type ) );
+	}
+
+	/** Is a no-op when the post type is not enabled. */
+	public function test_add_to_tracking_skipped_when_disabled(): void {
+		$post_type = $this->require_event_post_type();
+		$post      = $this->factory()->post->create_and_get( array( 'post_type' => $post_type, 'post_status' => 'publish' ) );
+		$this->tracker->add_to_tracking( $post->ID, $post );
+		$this->assertNotContains( $post->ID, $this->tracked( $post_type ) );
+	}
+
+	/** Prevents duplicate entries. */
+	public function test_add_to_tracking_prevents_duplicates(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$post = $this->factory()->post->create_and_get( array( 'post_type' => $post_type, 'post_status' => 'publish' ) );
+		$this->tracker->add_to_tracking( $post->ID, $post );
+		$this->tracker->add_to_tracking( $post->ID, $post );
+		$this->assertCount( 1, $this->tracked( $post_type ) );
+	}
+
+	// ── remove_from_tracking() ────────────────────────────────────────────────
+
+	/** Removes the correct ID from the per-type option. */
+	public function test_remove_from_tracking_removes_correct_id(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$this->seed( $post_type, array( 10, 20, 30 ) );
+		$post = new WP_Post( (object) array( 'ID' => 20, 'post_type' => $post_type ) );
+		$this->tracker->remove_from_tracking( 20, $post );
+		$tracked = $this->tracked( $post_type );
+		$this->assertNotContains( 20, $tracked );
 		$this->assertContains( 10, $tracked );
 		$this->assertContains( 30, $tracked );
-		$this->assertNotContains( 20, $tracked );
 	}
 
-	/**
-	 * Test remove_from_tracking handles empty option gracefully.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::remove_from_tracking
-	 */
-	public function test_remove_from_tracking_handles_empty(): void {
-		// No option set - should not error.
-		$this->tracker->remove_from_tracking( 42 );
-
-		// Should complete without errors.
-		$this->assertTrue( true );
+	/** Re-indexes the remaining array keys. */
+	public function test_remove_from_tracking_reindexes(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$this->seed( $post_type, array( 10, 20, 30 ) );
+		$post = new WP_Post( (object) array( 'ID' => 10, 'post_type' => $post_type ) );
+		$this->tracker->remove_from_tracking( 10, $post );
+		$this->assertSame( array( 0, 1 ), array_keys( $this->tracked( $post_type ) ) );
 	}
 
-	/**
-	 * Test remove_from_tracking handles non-array option gracefully.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::remove_from_tracking
-	 */
-	public function test_remove_from_tracking_handles_non_array(): void {
-		update_option( Option_Tracker::OPTION_KEY, 'not_an_array' );
-
-		// Should not throw.
-		$this->tracker->remove_from_tracking( 42 );
-
-		$this->assertTrue( true );
+	/** Is a no-op when the post type is not enabled. */
+	public function test_remove_from_tracking_skipped_when_disabled(): void {
+		$post_type = $this->require_event_post_type();
+		$this->seed( $post_type, array( 10, 20 ) );
+		$post = new WP_Post( (object) array( 'ID' => 10, 'post_type' => $post_type ) );
+		$this->tracker->remove_from_tracking( 10, $post );
+		$this->assertContains( 10, $this->tracked( $post_type ) );
 	}
 
-	/**
-	 * Test remove_from_tracking re-indexes array keys.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::remove_from_tracking
-	 */
-	public function test_remove_from_tracking_reindexes_keys(): void {
-		update_option( Option_Tracker::OPTION_KEY, array( 10, 20, 30 ) );
-
-		$this->tracker->remove_from_tracking( 10 );
-
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
-
-		// Keys should be sequential (0, 1) not (1, 2).
-		$this->assertEquals( array( 20, 30 ), $tracked );
-		$this->assertSame( array( 0, 1 ), array_keys( $tracked ) );
+	/** Falls back to scrubbing all enabled types when post type cannot be resolved. */
+	public function test_remove_from_tracking_fallback_scrubs_enabled_types(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$this->seed( $post_type, array( 99 ) );
+		// post ID 99 does not exist → resolve_post_type returns '' → fallback path.
+		$this->tracker->remove_from_tracking( 99, 0 );
+		$this->assertNotContains( 99, $this->tracked( $post_type ) );
 	}
 
-	/**
-	 * Test add_to_tracking adds an event ID to the option.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::add_to_tracking
-	 */
-	public function test_add_to_tracking_adds_event_id(): void {
-		$this->tracker->add_to_tracking( 42 );
+	// ── validate_events_ended() ───────────────────────────────────────────────
 
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
-
-		$this->assertCount( 1, $tracked );
-		$this->assertContains( 42, $tracked );
-	}
-
-	/**
-	 * Test add_to_tracking prevents duplicates.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::add_to_tracking
-	 */
-	public function test_add_to_tracking_prevents_duplicates(): void {
-		$this->tracker->add_to_tracking( 42 );
-		$this->tracker->add_to_tracking( 42 );
-
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
-
-		$this->assertCount( 1, $tracked );
-	}
-
-	/**
-	 * Test add_to_tracking handles non-array option gracefully.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::add_to_tracking
-	 */
-	public function test_add_to_tracking_handles_non_array(): void {
-		update_option( Option_Tracker::OPTION_KEY, 'not_an_array' );
-
-		$this->tracker->add_to_tracking( 42 );
-
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
-
-		$this->assertIsArray( $tracked );
-		$this->assertContains( 42, $tracked );
-	}
-
-	/**
-	 * Test that tracking hooks are NOT registered when feature is disabled.
-	 *
-	 * Since the singleton pattern means hooks are registered once at init time,
-	 * and the feature is disabled by default, the tracker hooks should not be present.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker
-	 */
-	public function test_tracking_hook_registration_default(): void {
-		// By default, the feature is disabled, so remove_from_tracking
-		// should NOT be hooked to gatherpress_event_ended.
-		$priority = has_action(
-			Cron_Scheduler::ACTION_HOOK,
-			array( $this->tracker, 'remove_from_tracking' )
-		);
-
-		// When disabled, has_action returns false.
-		$this->assertFalse(
-			$priority,
-			'remove_from_tracking should not be hooked when feature is disabled'
-		);
-	}
-
-	/**
-	 * Test that validate_events_ended handles empty tracking list.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::validate_events_ended
-	 */
-	public function test_validate_events_ended_handles_empty_list(): void {
-		delete_option( Option_Tracker::OPTION_KEY );
-
-		// Should complete without errors.
+	/** Skips disabled post types — their option is left untouched. */
+	public function test_validate_events_ended_skips_disabled_types(): void {
+		$post_type = $this->require_event_post_type();
+		$this->seed( $post_type, array( 999999 ) );
 		$this->tracker->validate_events_ended();
-
-		$this->assertTrue( true );
+		$this->assertContains( 999999, $this->tracked( $post_type ) );
 	}
 
-	/**
-	 * Test that validate_events_ended handles non-array option.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::validate_events_ended
-	 */
-	public function test_validate_events_ended_handles_non_array(): void {
-		update_option( Option_Tracker::OPTION_KEY, 'invalid' );
-
-		// Should complete without errors.
-		$this->tracker->validate_events_ended();
-
-		$this->assertTrue( true );
-	}
-
-	/**
-	 * Test that validate_events_ended cleans up non-existent posts.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::validate_events_ended
-	 */
+	/** Removes stale IDs for non-existent posts (enabled type). */
 	public function test_validate_events_ended_cleans_nonexistent_posts(): void {
-		// Track a non-existent post ID.
-		update_option( Option_Tracker::OPTION_KEY, array( 999999 ) );
-
-		// This will attempt to instantiate GatherPress Core\Event, which should
-		// handle non-existent posts gracefully by removing them from tracking.
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$this->seed( $post_type, array( 999999 ) );
 		$this->tracker->validate_events_ended();
-
-		$tracked = get_option( Option_Tracker::OPTION_KEY, array() );
-
-		// Non-existent post should be removed from tracking.
-		$this->assertNotContains( 999999, $tracked );
+		$this->assertNotContains( 999999, $this->tracked( $post_type ) );
 	}
 
-	/**
-	 * Test the daily cron hook is NOT scheduled when feature is disabled.
-	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker
-	 */
-	public function test_daily_cron_not_scheduled_when_disabled(): void {
+	/** Handles an empty tracking list without errors. */
+	public function test_validate_events_ended_handles_empty_list(): void {
+		$post_type = $this->require_event_post_type();
+		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
+		$this->tracker->validate_events_ended();
+		$this->assertTrue( true );
+	}
+
+	// ── Hook registration ─────────────────────────────────────────────────────
+
+	/** remove_from_tracking is always registered on ACTION_HOOK (guard is inside the method). */
+	public function test_remove_from_tracking_always_hooked(): void {
+		$this->assertNotFalse(
+			has_action( Cron_Scheduler::ACTION_HOOK, array( $this->tracker, 'remove_from_tracking' ) ),
+			'remove_from_tracking should always be registered on ACTION_HOOK'
+		);
+	}
+
+	/** Daily cron is not scheduled when no post type is enabled. */
+	public function test_daily_cron_not_scheduled_when_all_disabled(): void {
 		$this->assertFalse(
 			wp_next_scheduled( Option_Tracker::CRON_HOOK ),
-			'Daily tracker cron should not be scheduled when feature is disabled'
+			'Daily cron should not be scheduled when no post type is enabled'
 		);
 	}
 }

--- a/tests/integration/UpcomingEventsOptionTrackerTest.php
+++ b/tests/integration/UpcomingEventsOptionTrackerTest.php
@@ -10,15 +10,29 @@ use GatherPress_Cache_Invalidation_Hooks\Cron_Scheduler;
 use GatherPress_Cache_Invalidation_Hooks\Option_Tracker;
 
 /**
+ * Tests for Option_Tracker.
+ *
  * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker
  */
 class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 
+	/**
+	 * The option tracker instance under test.
+	 *
+	 * @var Option_Tracker
+	 */
 	private Option_Tracker $tracker;
 
-	/** @var string[] */
+	/**
+	 * Post types that declare gatherpress-event-date support in this environment.
+	 *
+	 * @var string[]
+	 */
 	private array $supporting_types;
 
+	/**
+	 * Set up test fixtures.
+	 */
 	public function set_up(): void {
 		parent::set_up();
 		$this->tracker          = Option_Tracker::get_instance();
@@ -26,6 +40,9 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 		$this->delete_all_tracking_options();
 	}
 
+	/**
+	 * Tear down — remove filters and clean options.
+	 */
 	public function tear_down(): void {
 		remove_all_filters( 'gatherpress_upcoming_events_option_tracker_enabled' );
 		remove_all_filters( 'gatherpress_upcoming_tracker_enabled' );
@@ -38,12 +55,18 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 
 	// ── Helpers ───────────────────────────────────────────────────────────────
 
+	/**
+	 * Deletes all per-type tracking options.
+	 */
 	private function delete_all_tracking_options(): void {
 		foreach ( $this->supporting_types as $pt ) {
 			delete_option( $this->tracker->option_key_for( $pt ) );
 		}
 	}
 
+	/**
+	 * Returns a supported post type or skips when GatherPress is not active.
+	 */
 	private function require_event_post_type(): string {
 		if ( ! in_array( 'gatherpress_event', $this->supporting_types, true ) ) {
 			$this->markTestSkipped( 'gatherpress_event post type not available.' );
@@ -51,10 +74,22 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 		return 'gatherpress_event';
 	}
 
+	/**
+	 * Seeds the tracking option for a post type with the given IDs.
+	 *
+	 * @param string $post_type Post type slug.
+	 * @param int[]  $ids       IDs to write.
+	 */
 	private function seed( string $post_type, array $ids ): void {
 		update_option( $this->tracker->option_key_for( $post_type ), $ids );
 	}
 
+	/**
+	 * Reads the tracking option for a post type.
+	 *
+	 * @param string $post_type Post type slug.
+	 * @return int[]
+	 */
 	private function tracked( string $post_type ): array {
 		return get_option( $this->tracker->option_key_for( $post_type ), array() );
 	}
@@ -124,12 +159,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 
 	/**
 	 * Deprecated filter still enables tracking and fires a deprecation notice
-	 * via apply_filters_deprecated() (which calls doing_it_wrong internally).
+	 * via apply_filters_deprecated() — caught by setExpectedDeprecated().
 	 */
 	public function test_deprecated_filter_honoured_with_notice(): void {
 		$post_type = $this->require_event_post_type();
 		add_filter( 'gatherpress_upcoming_events_option_tracker_enabled', '__return_true' );
-		$this->setExpectedIncorrectUsage( 'apply_filters_deprecated' );
+		$this->setExpectedDeprecated( 'gatherpress_upcoming_events_option_tracker_enabled' );
 		$this->assertTrue( $this->tracker->is_post_type_enabled( $post_type ) );
 	}
 
@@ -137,7 +172,7 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 	public function test_deprecated_filter_false_still_fires_notice(): void {
 		$post_type = $this->require_event_post_type();
 		add_filter( 'gatherpress_upcoming_events_option_tracker_enabled', '__return_false' );
-		$this->setExpectedIncorrectUsage( 'apply_filters_deprecated' );
+		$this->setExpectedDeprecated( 'gatherpress_upcoming_events_option_tracker_enabled' );
 		$this->assertFalse( $this->tracker->is_post_type_enabled( $post_type ) );
 	}
 
@@ -168,7 +203,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 		$post_type = $this->require_event_post_type();
 		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
 
-		$post = $this->factory()->post->create_and_get( array( 'post_type' => $post_type, 'post_status' => 'publish' ) );
+		$post = $this->factory()->post->create_and_get(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
+			) 
+		);
 		$this->tracker->add_to_tracking( $post->ID, $post );
 
 		$this->assertContains( $post->ID, $this->tracked( $post_type ) );
@@ -177,7 +217,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 	/** Is a no-op when the post type is not enabled. */
 	public function test_add_to_tracking_skipped_when_disabled(): void {
 		$post_type = $this->require_event_post_type();
-		$post      = $this->factory()->post->create_and_get( array( 'post_type' => $post_type, 'post_status' => 'publish' ) );
+		$post      = $this->factory()->post->create_and_get(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
+			) 
+		);
 		$this->tracker->add_to_tracking( $post->ID, $post );
 		$this->assertNotContains( $post->ID, $this->tracked( $post_type ) );
 	}
@@ -186,7 +231,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 	public function test_add_to_tracking_prevents_duplicates(): void {
 		$post_type = $this->require_event_post_type();
 		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
-		$post = $this->factory()->post->create_and_get( array( 'post_type' => $post_type, 'post_status' => 'publish' ) );
+		$post = $this->factory()->post->create_and_get(
+			array(
+				'post_type'   => $post_type,
+				'post_status' => 'publish',
+			) 
+		);
 		$this->tracker->add_to_tracking( $post->ID, $post );
 		$this->tracker->add_to_tracking( $post->ID, $post );
 		$this->assertCount( 1, $this->tracked( $post_type ) );
@@ -199,7 +249,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 		$post_type = $this->require_event_post_type();
 		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
 		$this->seed( $post_type, array( 10, 20, 30 ) );
-		$post = new WP_Post( (object) array( 'ID' => 20, 'post_type' => $post_type ) );
+		$post = new WP_Post(
+			(object) array(
+				'ID'        => 20,
+				'post_type' => $post_type,
+			) 
+		);
 		$this->tracker->remove_from_tracking( 20, $post );
 		$tracked = $this->tracked( $post_type );
 		$this->assertNotContains( 20, $tracked );
@@ -212,7 +267,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 		$post_type = $this->require_event_post_type();
 		add_filter( "{$post_type}_upcoming_tracker_enabled", '__return_true' );
 		$this->seed( $post_type, array( 10, 20, 30 ) );
-		$post = new WP_Post( (object) array( 'ID' => 10, 'post_type' => $post_type ) );
+		$post = new WP_Post(
+			(object) array(
+				'ID'        => 10,
+				'post_type' => $post_type,
+			) 
+		);
 		$this->tracker->remove_from_tracking( 10, $post );
 		$this->assertSame( array( 0, 1 ), array_keys( $this->tracked( $post_type ) ) );
 	}
@@ -221,7 +281,12 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 	public function test_remove_from_tracking_skipped_when_disabled(): void {
 		$post_type = $this->require_event_post_type();
 		$this->seed( $post_type, array( 10, 20 ) );
-		$post = new WP_Post( (object) array( 'ID' => 10, 'post_type' => $post_type ) );
+		$post = new WP_Post(
+			(object) array(
+				'ID'        => 10,
+				'post_type' => $post_type,
+			) 
+		);
 		$this->tracker->remove_from_tracking( 10, $post );
 		$this->assertContains( 10, $this->tracked( $post_type ) );
 	}
@@ -265,7 +330,7 @@ class UpcomingEventsOptionTrackerTest extends WP_UnitTestCase {
 
 	// ── Hook registration ─────────────────────────────────────────────────────
 
-	/** remove_from_tracking is always registered on ACTION_HOOK (guard is inside the method). */
+	/** Remove_from_tracking is always registered on ACTION_HOOK (guard is inside the method). */
 	public function test_remove_from_tracking_always_hooked(): void {
 		$this->assertNotFalse(
 			has_action( Cron_Scheduler::ACTION_HOOK, array( $this->tracker, 'remove_from_tracking' ) ),

--- a/tests/unit/SchedulerClassTest.php
+++ b/tests/unit/SchedulerClassTest.php
@@ -143,7 +143,9 @@ class SchedulerClassTest extends WP_UnitTestCase {
 	public function test_option_tracker_public_methods_exist(): void {
 		$expected_methods = array(
 			'get_instance',
-			'is_tracker_enabled',
+			'is_post_type_enabled',
+			'any_post_type_enabled',
+			'option_key_for',
 			'add_to_tracking',
 			'remove_from_tracking',
 			'validate_events_ended',
@@ -257,16 +259,19 @@ class SchedulerClassTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that is_tracker_enabled returns bool.
+	 * Test that is_post_type_enabled and any_post_type_enabled return bool.
 	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::is_tracker_enabled
+	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::is_post_type_enabled
+	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::any_post_type_enabled
 	 */
-	public function test_option_tracker_is_tracker_enabled_return_type(): void {
-		$reflection  = new ReflectionMethod( Option_Tracker::class, 'is_tracker_enabled' );
-		$return_type = $reflection->getReturnType();
+	public function test_option_tracker_enablement_methods_return_bool(): void {
+		foreach ( array( 'is_post_type_enabled', 'any_post_type_enabled' ) as $method_name ) {
+			$reflection  = new ReflectionMethod( Option_Tracker::class, $method_name );
+			$return_type = $reflection->getReturnType();
 
-		$this->assertNotNull( $return_type );
-		$this->assertEquals( 'bool', $return_type->getName() );
+			$this->assertNotNull( $return_type, "{$method_name} must declare a return type" );
+			$this->assertEquals( 'bool', $return_type->getName(), "{$method_name} must return bool" );
+		}
 	}
 
 	/**
@@ -287,17 +292,28 @@ class SchedulerClassTest extends WP_UnitTestCase {
 	 */
 	public function test_option_tracker_constants(): void {
 		$this->assertEquals( 'gatherpress_validate_events_ended', Option_Tracker::CRON_HOOK );
-		$this->assertEquals( 'gatherpress_upcoming_events', Option_Tracker::OPTION_KEY );
+		$this->assertEquals( 'upcoming_', Option_Tracker::OPTION_KEY_PREFIX );
 	}
 
 	/**
-	 * Test that is_tracker_enabled returns false by default.
+	 * Test that is_post_type_enabled returns false for all types by default.
 	 *
-	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::is_tracker_enabled
+	 * @covers \GatherPress_Cache_Invalidation_Hooks\Option_Tracker::is_post_type_enabled
 	 */
 	public function test_option_tracker_disabled_by_default(): void {
-		$tracker = Option_Tracker::get_instance();
+		$tracker          = Option_Tracker::get_instance();
+		$supporting_types = get_post_types_by_support( 'gatherpress-event-date' );
 
-		$this->assertFalse( $tracker->is_tracker_enabled() );
+		if ( empty( $supporting_types ) ) {
+			$this->assertFalse( $tracker->any_post_type_enabled() );
+			return;
+		}
+
+		foreach ( $supporting_types as $post_type ) {
+			$this->assertFalse(
+				$tracker->is_post_type_enabled( $post_type ),
+				"Expected tracker disabled by default for {$post_type}"
+			);
+		}
 	}
 }


### PR DESCRIPTION
Previously Option_Tracker stored all upcoming event IDs in a single
`gatherpress_upcoming_events` option regardless of post type, and a single `gatherpress_upcoming_events_option_tracker_enabled` filter switched the entire subsystem on or off.

 - ('upcoming_') and a new option_key_for( $post_type ) helper that produces upcoming_{post_type}s (e.g. upcoming_gatherpress_events). Each supporting post type now owns its own wp_option; IDs from different types can no longer be mixed.
 - Replace is_tracker_enabled() with two public methods: · is_post_type_enabled( $post_type ) — three-tier resolution:
     1. Deprecated gatherpress_upcoming_events_option_tracker_enabled, handled via apply_filters_deprecated() so existing callbacks still run while a notice is emitted.
     2. General gatherpress_upcoming_tracker_enabled (enables all supporting types at once; receives $post_type as second arg). 3. Per-type {$post_type}_upcoming_tracker_enabled (e.g. gatherpress_event_upcoming_tracker_enabled). · any_post_type_enabled() — returns true when at least one supporting type is enabled; used to gate cron scheduling.
 - Remove the all-or-nothing guard from setup_hooks(); hooks are now always registered. Each runtime callback (add_to_tracking, remove_from_tracking, validate_events_ended_for_type) calls is_post_type_enabled() for its specific post type so newly enabled types take effect without a plugin reactivation cycle.
 - validate_events_ended() iterates get_post_types_by_support() and delegates to new validate_events_ended_for_type( $post_type ), which guards on is_post_type_enabled() and skips disabled types without touching their options.
 - remove_from_tracking() fallback path (unresolvable post type) now only scrubs enabled types instead of all supporting types.

 - Add seed() / tracked() / require_event_post_type() / delete_all_tracking_options() helpers; tear_down() cleans per-type filters and options.
 - New test groups: option_key_for, is_post_type_enabled (default, general filter + arg pass-through, per-type filter isolation, deprecated filter × 2), any_post_type_enabled (× 3), add_to_tracking (correct option, skip when disabled, dedup), remove_from_tracking (correct ID, re-index, skip when disabled, fallback scrub), validate_events_ended (skip disabled, clean stale, empty list), hook registration (always-hooked, cron not scheduled).
 - setExpectedIncorrectUsage updated from 'is_post_type_enabled' to 'apply_filters_deprecated' to match WP's internal notice source.